### PR TITLE
added a cohort grouper function

### DIFF
--- a/colins_group_maker/grouper.R
+++ b/colins_group_maker/grouper.R
@@ -1,0 +1,13 @@
+# Set up the function;
+grouper <- function(cohort, number_of_groups = 2){
+
+# Expect number_of_cohorts to be numeric;
+  if(!is.numeric(number_of_groups)) {
+    stop(call. = TRUE, "D'oh!  Use a number for how many groups you need...")
+  }
+
+# Generate groups;
+  cohort |>
+    sample(length(cohort)) |>
+    split(1:number_of_groups) # enter no. groups needed
+}


### PR DESCRIPTION
Pushed my own version of a cohort group creator function to use when splitting cohorts up for labs etc.  Think there must be a more elegant way to define cohorts more globally, but don't know what that might be at the moment.

![image](https://github.com/jmcvw/ccwickedwango/assets/98903525/4c5277d0-0471-4388-9aab-892aa097bd8b)